### PR TITLE
Correcting a spelling error in telephone hello world example

### DIFF
--- a/t/telephone
+++ b/t/telephone
@@ -1,2 +1,2 @@
-#How to Spell HELO WORLD on a standard telephone keypad
+#How to Spell HELLO WORLD on a standard telephone keypad
 435509 990753


### PR DESCRIPTION
This is a simple change, just fixing a simple typo in the comments of the hello world example in telephone digits (t/telephone)
