### PR TITLE
objc.m Rewritten.

### DIFF
--- a/o/objc.m
+++ b/o/objc.m
@@ -1,7 +1,21 @@
-#import <Cocoa/Cocoa.h>
+/*
+ Build on OS X: 
+ clang -framework Foundation -fobjc-arc objc.m -o objc
+ 
+ Build on Linux with GNUstep:
+ clang `gnustep-config --objc-flags` `gnustep-config --base-libs` -fobjc-nonfragile-abi -fobjc-arc objc.m -o objc
+ */
 
-int main(int argc, char *argv[])
+#import <Foundation/Foundation.h>
+
+int main(void)
 {
-    NSLog(@"Hello, World!\n");
-	return 0;
+    @autoreleasepool
+    {
+        NSFileHandle *_stderr = [NSFileHandle fileHandleWithStandardError];
+        NSString *string = @"hello, world\n";
+        NSData *data = [string dataUsingEncoding:[NSString defaultCStringEncoding]];
+        [_stderr writeData:data];
+    }
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The original objc.m used NSLog() which:
1) generated a lot of useless output, and
2) did not actually used Objective-C objects.

I wrote a slightly complicated one using NSFileHandle, which:
1) write a short line to stderr without any extra data,
2) demonstrated using of Objective-C objects, and
3) is complete object-oriented code.

In this example, I used 3 classes, NSString, NSData and NSFileHandle.

Also, this example included a build instruction for both OS X using Xcode, and Linux using clang and GNUstep. Code asks for Objective-C ARC.
