### PR TITLE
Convert to Standard Forth.

### DIFF
--- a/f/forth.f
+++ b/f/forth.f
@@ -1,1 +1,0 @@
-: HELLO S" Hello, world!" TELL CR ;

--- a/f/forth.fth
+++ b/f/forth.fth
@@ -1,0 +1,1 @@
+: HELLO ." Hello, world!" CR ;


### PR DESCRIPTION
The Forth program uses a non-standard word `TELL`.  Also, it's simpler to use `."` than `S"` and print the result.  Also, the `.f` file extension may clash with Fortran.