### PR TITLE
Updated rust.rs

### DIFF
--- a/r/rust.rs
+++ b/r/rust.rs
@@ -1,3 +1,3 @@
 fn main() {
-  io::println("Hello, world!");
+  println!("Hello, world!");
 }


### PR DESCRIPTION
Old Rust syntax no longer compiles.
Changed syntax to conform with Rust 1.0.