### PR TITLE
Use standard telephone keyboard layout

### DIFF
--- a/t/telephone
+++ b/t/telephone
@@ -1,2 +1,2 @@
 #How to Spell HELLO WORLD on a standard telephone keypad
-43550 90753
+43556 96753


### PR DESCRIPTION
A standard telephone keyboard uses "6" for "O", not "0". Do the same here.

For evidence of this being standard, see ISO/IEC 9995-8:2009 or E.161.