### PR TITLE
Replace ASCII APL with correct Unicode characters

### DIFF
--- a/a/apl.apl
+++ b/a/apl.apl
@@ -1,1 +1,2 @@
-[]<-'Hello World!'
+⎕←'Hello World!'
+


### PR DESCRIPTION
The existing declaration does nothing but generate syntax errors in the GNU APL interpreter. No idea about other interpreters like Dyalog, etc.