### PR TITLE
Create Z80_Assembler_(ZX_Spectrum).asm

### DIFF
--- a/z/Z80_Assembler_(ZX_Spectrum).asm
+++ b/z/Z80_Assembler_(ZX_Spectrum).asm
@@ -1,0 +1,21 @@
+org $6000
+	ld bc, STRING
+	ld de, SCR
+
+LOOP
+	ld a, (bc)
+	cp 0
+	jr z, EXIT
+	rst $10
+	inc bc
+	inc de
+	jr LOOP
+
+EXIT
+	ret
+	
+SCR equ 16384
+
+STRING
+	defb "Hello World!"
+	defb 13, 0


### PR DESCRIPTION
Added the ZX Spectrum's Z80 Assembler (it may run on other platforms, but I wrote it for the ZX Spectrum). Compiled using `pasmo`, it can be ran using `PRINT USR 24576`.