### PR TITLE
Update kotlin.kt

### DIFF
--- a/k/kotlin.kt
+++ b/k/kotlin.kt
@@ -1,5 +1,5 @@
 package hello
  
-fun main(args : Array<String>) {
+fun main(args: Array<String>) {
   println("Hello, world!")
 }


### PR DESCRIPTION
Reformat per coding conventions.

> There is a space before colon where colon separates type and supertype and there’s no space where colon separates instance and type

via: https://kotlinlang.org/docs/reference/coding-conventions.html#colon
