### PR TITLE
Add Common Lisp example

### DIFF
--- a/c/common-lisp.lisp
+++ b/c/common-lisp.lisp
@@ -1,0 +1,4 @@
+;; Common Lisp
+
+(defun hello-world ()
+  (format t "Hello World~%"))


### PR DESCRIPTION
Common Lisp is distinct from plain old `Lisp' in that
Lisp doesn't have FORMAT.  That was added in Common Lisp,
in Guy Steele's book Common Lisp the Language, in 1984.
