### PR TITLE
Why not make the text visible?

### DIFF
--- a/p/processing.pde
+++ b/p/processing.pde
@@ -1,4 +1,5 @@
 size(128, 128);
 background(0);
 textAlign(CENTER, CENTER);
+fill(255);
 text("Hello World", width / 2, height / 2);


### PR DESCRIPTION
By itself, the previous Processing sketch just displays a black background. That's because the colour of the text is black by default. So to make it visible, I added `fill(255)` to change the text's colour to white.