### PR TITLE
Compatibility with older versions of Python

### DIFF
--- a/list_langs.py
+++ b/list_langs.py
@@ -16,10 +16,10 @@ readme.write('\n### This repository currently contains "Hello World" programs in
 for dir in os.listdir('.'):
   if not (dir == '.' or dir == '..' or dir[0] == '.' or os.path.isfile(dir)):
     for file in os.listdir(dir):
-      if os.path.isfile(f'{dir}/{file}'):
+      if os.path.isfile(os.path.join(dir, file)):
         lang = ''
         for str in file[0:(len(file) if file.find('.') == -1 else file.find('.'))].replace('-', ' ').replace('_', ' ').split():
           lang += str.capitalize() + ' '
-        readme.write(f'* [{lang[:-1]}]({dir if dir != "#" else "%23"}/{file})\n') # Cut trailing space
+        readme.write('* [{}]({})\n'.format(lang[:-1], os.path.join(dir if dir != "#" else "%23", file))) # Cut trailing space
 
 readme.close()


### PR DESCRIPTION
This closes #395. The old version of `list_langs.py` only worked on Python 3.6 because it used the new "f-strings." As was pointed out in #395, Python 3.6 does not yet have widespread use and it's nice to maintain compatibility with older Python versions so that more people can use it and develop with it.

My new version of the script was tested on Python 3.5.2 and Python 2.7.12