### PR TITLE
Rename variables in list-langs.py

### DIFF
--- a/list_langs.py
+++ b/list_langs.py
@@ -13,13 +13,13 @@ with open('README_nolist.md', 'r') as temp:
 readme.write('\n### This repository currently contains "Hello World" programs in the following languages:\n')
 
 # List the available languages
-for dir in os.listdir('.'):
-  if not (dir == '.' or dir == '..' or dir[0] == '.' or os.path.isfile(dir)):
-    for file in os.listdir(dir):
-      if os.path.isfile(os.path.join(dir, file)):
+for dirname in os.listdir('.'):
+  if not (dirname == '.' or dirname == '..' or dirname[0] == '.' or os.path.isfile(dirname)):
+    for filename in os.listdir(dirname):
+      if os.path.isfile(os.path.join(dirname, filename)):
         lang = ''
-        for str in file[0:(len(file) if file.find('.') == -1 else file.find('.'))].replace('-', ' ').replace('_', ' ').split():
-          lang += str.capitalize() + ' '
-        readme.write('* [{}]({})\n'.format(lang[:-1], os.path.join(dir if dir != "#" else "%23", file))) # Cut trailing space
+        for name in filename[0:(len(filename) if filename.find('.') == -1 else filename.find('.'))].replace('-', ' ').replace('_', ' ').split():
+          lang += name.capitalize() + ' '
+        readme.write('* [{}]({})\n'.format(lang[:-1], os.path.join(dirname if dirname != "#" else "%23", filename))) # Cut trailing space
 
 readme.close()


### PR DESCRIPTION
[`dir`](https://docs.python.org/3/library/functions.html#dir) is a Python built-in function, [`str`](https://docs.python.org/3/library/stdtypes.html#str) is a Python built-in type, and `file` was a built-in type until it was [removed in Python 3.0](https://docs.python.org/release/3.0/whatsnew/3.0.html#builtins). Therefore, it is generally considered bad practice to name variables with these names, since those variables then overshadow and prevent the use of `str()`, `dir()`, and `file()`. 