### PR TITLE
Remove Write-Output call from PowerShell example

### DIFF
--- a/p/powershell.ps1
+++ b/p/powershell.ps1
@@ -1,1 +1,1 @@
-Write-Output 'Hello World'
+'Hello World'


### PR DESCRIPTION
Default behavior of PowerShell is to send any objects at end of pipeline to output.
There is no need to explicitly call Write-Output cmdlet.

Fixes #416