### PR TITLE
Update coffeescript.coffee to use alert

### DIFF
--- a/c/coffeescript.coffee
+++ b/c/coffeescript.coffee
@@ -1,1 +1,1 @@
-console.log "Hello, World!"
+alert "Hello, World!"


### PR DESCRIPTION
Coffeescript documentation uses _alert_ for messages rather than _console.log_