### PR TITLE
Add comment to namespace definition

### DIFF
--- a/c/c++.cpp
+++ b/c/c++.cpp
@@ -1,6 +1,6 @@
 #include <iostream> // include API
 
-using namespace std;
+using namespace std; //defines namespace used, avoids having to type 'std::' prefix
 
 int main() // the main code portion of a C++ program
 {


### PR DESCRIPTION
Adds a comment to line 3 to make the use of namespace definition clear (to beginners or otherwise).