### PR TITLE
Update and rename python.py to python2.py

### DIFF
--- a/p/python.py
+++ b/p/python.py
@@ -1,2 +1,0 @@
-#!/usr/bin/env python
-print "Hello World"

--- a/p/python2.py
+++ b/p/python2.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python2
+print "Hello World"


### PR DESCRIPTION
As Python 2 is not the default python verion on most of the modern operating systems, I guess it makes sense to add the version in shebang.