### PR TITLE
Revert "Update c++.cpp"

### DIFF
--- a/c/c++.cpp
+++ b/c/c++.cpp
@@ -1,8 +1,6 @@
 #include <iostream>
 
-using namespace std;
-
 int main()
 {
-   cout << "Hello World\n";
+   std::cout << "Hello World\n";
 }


### PR DESCRIPTION
B. Stroustrup, the author of C++, doesn't use "use namespace std;" in his
book. References: TC++PL4 §2.2.1 and TC++PL3 §3.2.

This reverts commit 8565caab82ac828813e9ef31b6abb92c79d4e87a.