### PR TITLE
Update Ada example

### DIFF
--- a/a/ada.ada
+++ b/a/ada.ada
@@ -1,5 +1,7 @@
-with Text_IO;
+with Ada.Text_IO;
+
 procedure Hello_World is
-	begin
-		Text_IO.Put_line("Hello World");
-	end Hello_World;
+   use Ada.Text_IO;
+begin
+   Put_line ("Hello World");
+end Hello_World;


### PR DESCRIPTION
The Text_IO package was Ada 83. Afterwards it is Ada.Text_IO.
The package is 'opened' with 'use Ada.Text_IO'
Conforming to usual style.