### PR TITLE
Fix Minecraft

### DIFF
--- a/m/Minecraft.mcfunction
+++ b/m/Minecraft.mcfunction
@@ -1,1 +1,1 @@
-/tellraw @p "Hello World"
+tellraw @p "Hello World"


### PR DESCRIPTION
Removed the `/` at the start of the first line due to the fact that MCF won't run any lines that start with `/`
