### PR TITLE
Follow Stroustrup's advice to avoid endl

### DIFF
--- a/c/C++.cpp
+++ b/c/C++.cpp
@@ -2,5 +2,5 @@
 
 int main()
 {
-   std::cout << "Hello World" << std::endl;
+   std::cout << "Hello World\n";
 }


### PR DESCRIPTION
See https://github.com/isocpp/CppCoreGuidelines/issues/357#issuecomment-153515258 and https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#slio50-avoid-endl

The creator of the language (Bjarne Stroustrup) has been avoiding the use of `std:endl` for over 15 years, and he recommends that others following his example. Rationale included in the guidelines linked by the second URL above.