### PR TITLE
Fix Assembler lc3

### DIFF
--- a/a/Assembler lc3.asm
+++ b/a/Assembler lc3.asm
@@ -2,5 +2,8 @@
 
 			LEA R0, HELLOWORLD
 			PUTS
+			HALT
 	
 HELLOWORLD	.STRINGZ "Hello World\n"
+
+			.END


### PR DESCRIPTION
The current LC-3 program does not halt after the PUTS, so it will then try to execute 'H', or 0x0048 as a word. This gets decoded as a branch to PC+0x48, but one that is never taken. Some simulators may reject this, as my humble implementation does on the basis that there's no way to write that in LC-3 assembly (the assembler interprets br as brnzp). Even if they treat each character of the .stringz as a no-op, the CPU would keep executing no-ops afterward (if memory is initialized to zero) or undefined behavior (if memory is not). So add a HALT to try and avoid weird behavior.

Also added a .end as some assemblers (such as my prototype which is very picky) will complain if you don't have one

Tested with https://ausb.in/novice/

## Adding a language

- [x] The code displays "Hello World"
- [x] I have updated the readme to include the new language
- [x] I have incremented the language count in the readme
