### PR TITLE
update Ruby.rb to use print instead of puts

### DIFF
--- a/r/Ruby.rb
+++ b/r/Ruby.rb
@@ -1,2 +1,2 @@
 #!/usr/bin/env ruby
-puts "Hello World"
+print "Hello World"


### PR DESCRIPTION
` puts` in ruby adds a newline, which contributing.md says to avoid if possible. `print` in ruby does not add a newline.

