### PR TITLE
Update C.c

### DIFF
--- a/c/C.c
+++ b/c/C.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 
-int main() {
+int main(void) {
 	printf("Hello World\n");
-	return 0;
 }


### PR DESCRIPTION
1. `()` in function declarations have been deprecated in C since the first C89/90 standard. In C prefer `(void)`.
2. `return 0` at the end of `main` is redundant in modern C (since C99). Since it is omitted in C++ version and since the apparent intent is to produce the most compact code, it might be good idea to remove it here as well.
