### PR TITLE
Rename WikiText to Wikitext.wiki

### DIFF
--- a/w/WikiText
+++ b/w/WikiText
@@ -1,1 +1,0 @@
-Hello World

--- a/w/Wikitext.wiki
+++ b/w/Wikitext.wiki
@@ -1,0 +1,1 @@
+Hello World


### PR DESCRIPTION
GitHub renders Wikitext syntax for files whose name ends with `.wiki`, `.wikitext`, or `.mediawiki`.