### PR TITLE
Avoid printing newline in R

### DIFF
--- a/r/R.R
+++ b/r/R.R
@@ -1,1 +1,1 @@
-cat("Hello World\n")
+cat("Hello World")


### PR DESCRIPTION
`\n` adds a newline, which contributing.md says to avoid if possible, without `\n`, there is no newline.