### PR TITLE
Broken Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Make sure to see [contributing.md](/contributing.md) for instructions on contrib
 * [~Belarusian](%23/~Belarusian)
 * [~Bengali](%23/~Bengali)
 * [~Bosnian](%23/~Bosnian)
-* [~Central Kurdish](%23/~Central Kurdish)
+* [~Central Kurdish](%23/~Central%20Kurdish)
 * [~Chinese](%23/~Chinese)
 * [~Czech](%23/~Czech)
 * [~Dutch](%23/~Dutch)


### PR DESCRIPTION
The link does not display as proper markdown changing the space to `%20` in the target should help.