### PR TITLE
Fix: PowerShell writes to output stream by default

### DIFF
--- a/p/PowerShell.ps1
+++ b/p/PowerShell.ps1
@@ -1,1 +1,1 @@
-Write-Host 'Hello World'
+'Hello World'


### PR DESCRIPTION
Write-Host is superfluous, because PowerShell sends objects (including "Hello, World" text) to output stream ("stdout") by default.

More information can be found [here](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_output_streams).
