### PR TITLE
Add Cython

### DIFF
--- a/c/Cython.pyx
+++ b/c/Cython.pyx
@@ -1,0 +1,1 @@
+print "Hello World",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Thanks to everyone who continues to contribute; new languages are created every 
 Make sure to see [contributing.md](/contributing.md) for instructions on contributing to the project!
 
 <!--Languages start-->
-## Languages (999 total)
+## Languages (1000 total)
 
 * [!](%23/%21)
 * [!@#$%^&*()_+](%23/%21%40%23%24%25%5E%26%E2%88%97%28%29_%2B)
@@ -283,6 +283,7 @@ Make sure to see [contributing.md](/contributing.md) for instructions on contrib
 * [Curry](c/Curry.curry)
 * [Cyclone](c/Cyclone.cyc)
 * [CypherNeo4j](c/CypherNeo4j.cypher)
+* [Cython](c/Cython.pyx)
 * [Cω](c/C%CF%89.cs)
 * [C*](c/C%E2%88%97)
 * [Ć](c/%C4%86.ci)


### PR DESCRIPTION
## Adding a language

- [X] The code displays "Hello World" ([tio.run](https://tio.run) may help for testing)
- [X] I have no association with the language
- [X] There are no copyright issues with this code
- [X] The language has not been added prior to this pull request

#### Link to programming language:

https://cython.org/ and https://cython.readthedocs.io/en/stable/src/userguide/index.html

#### To run / test

Make a setup.py (needed for compiling), with the following content:
```python
from setuptools import setup
from Cython.Build import cythonize

setup(ext_modules=cythonize("Cython.pyx")
```

Store the setup.py in the same folder as Cython.pyx.

To compile the module, run:
```
pip install Cython
python setup.py build_ext --inplace
```
Then execute the module with `python -c "import Cython"` (needs to be in the same directory as Cython.so / Cython.pyd)