### PR TITLE
Remove unused import from FastAPI.py

### DIFF
--- a/f/FastAPI.py
+++ b/f/FastAPI.py
@@ -1,4 +1,4 @@
-from fastapi import Body, FastAPI
+from fastapi import FastAPI
 
 app = FastAPI()
 


### PR DESCRIPTION
## ~Adding~ Updating a language

I removed the fastapi.Body import as it is not being used.

- [x] The code displays "Hello World" ([tio.run](https://tio.run) may help for testing)
- [x] I have no association with the language
- [x] There are no copyright issues with this code
- [ ] The language has not been added prior to this pull request
- [ ] I have updated the README

#### Link to programming language: 
https://fastapi.tiangolo.com/
https://www.python.org/